### PR TITLE
update -> develop for bugfix

### DIFF
--- a/containers/stacks/cloud/dist.docker-compose.yml
+++ b/containers/stacks/cloud/dist.docker-compose.yml
@@ -39,8 +39,12 @@ services:
       - proxy
       - cloud-net
     environment:
-      - APACHE_DISABLE_REWRITE_IP=1
+      # Required for redirects
+      - OVERWRITEHOST=${DOMAIN}
+      - OVERWRITEPROTOCOL=https
       - TRUSTED_PROXIES=${TRUSTED_PROXIES}
+      - APACHE_DISABLE_REWRITE_IP=1
+      # Database variables
       - MYSQL_HOST=cloud-db
       - MYSQL_DATABASE=${DB_DB}
       - MYSQL_USER=${DB_USER}


### PR DESCRIPTION
Added new environment variables to the nextcloud stack config for overwriting domain and HTTP protocol. 

This fixes an error that occurs when hitting "grant access" in the sign-up flow that causes a connection loop instead of connecting.