### PR TITLE
develop -> main for bugfix

### DIFF
--- a/containers/core/gateway/dist.config.yaml
+++ b/containers/core/gateway/dist.config.yaml
@@ -7,9 +7,14 @@ api:
 
 entryPoints:
   http:
-    address: ":80"
+    address: :80
+    http:
+      redirections:
+        entryPoint:
+          to: https
+          scheme: https
   https:
-    address: ":443"
+    address: :443
 
 providers:
   docker:


### PR DESCRIPTION
Added new environment variables to the nextcloud stack config for overwriting domain and HTTP protocol.

This fixes an error that occurs when hitting "grant access" in the sign-up flow that causes a connection loop instead of connecting.